### PR TITLE
chore: bump ingress-nginx v3.15.2

### DIFF
--- a/.holo/sources/ingress-nginx.toml
+++ b/.holo/sources/ingress-nginx.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/kubernetes/ingress-nginx"
-ref = "refs/tags/ingress-nginx-2.11.1"
+ref = "refs/tags/ingress-nginx-3.15.2"


### PR DESCRIPTION
Big jump, needs to be tested out on a cluster before merged