### PR TITLE
feat: implement grafana dashboard

### DIFF
--- a/.holo/branches/k8s-blueprint/grafana/helm-chart.toml
+++ b/.holo/branches/k8s-blueprint/grafana/helm-chart.toml
@@ -1,0 +1,7 @@
+[holomapping]
+holosource = "grafana"
+root = "charts/grafana"
+files = [
+  "**",
+  "!templates/tests/**"
+]

--- a/.holo/sources/grafana.toml
+++ b/.holo/sources/grafana.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/grafana/helm-charts.git"
+ref = "refs/tags/grafana-6.2.1"

--- a/k8s-common/.holo/lenses/grafana.toml
+++ b/k8s-common/.holo/lenses/grafana.toml
@@ -1,0 +1,19 @@
+[hololens]
+package = "holo/lens-helm3/1.3"
+before = "k8s-normalize"
+
+[hololens.input]
+root = "grafana"
+files = "**"
+
+[hololens.output]
+merge = "replace"
+
+[hololens.helm]
+namespace = "grafana"
+release_name = "grafana"
+
+chart_path = "helm-chart"
+value_files = [
+    "release-values.yaml"
+]

--- a/k8s-common/.holo/lenses/grafana.toml
+++ b/k8s-common/.holo/lenses/grafana.toml
@@ -15,5 +15,7 @@ release_name = "grafana"
 
 chart_path = "helm-chart"
 value_files = [
+    "default-values.yaml",
+    "provider-values.yaml",
     "release-values.yaml"
 ]

--- a/k8s-common/grafana/default-values.yaml
+++ b/k8s-common/grafana/default-values.yaml
@@ -1,0 +1,48 @@
+# These values as applied first as template-provided defaults
+---
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+
+      - name: Prometheus
+        type: prometheus
+        url: http://prometheus-server.prometheus.svc.cluster.local
+        isDefault: true
+
+dashboardProviders:
+
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      editable: true
+      options:
+        path: /var/lib/grafana/dashboards/default
+
+dashboards:
+
+  default:
+
+    node-exporter:
+      gnetId: 1860
+      revision: 22
+      datasource: Prometheus
+
+    workload-view:
+      gnetId: 8588
+      revision: 1
+      datasource: Prometheus
+
+    cluster-view:
+      gnetId: 7249
+      revision: 1
+      datasource: Prometheus
+
+persistence:
+
+  enabled: true

--- a/k8s-common/grafana/provider-values.yaml
+++ b/k8s-common/grafana/provider-values.yaml
@@ -1,0 +1,1 @@
+# These values as applied second as provider-level defaults

--- a/k8s-common/grafana/release-values.yaml
+++ b/k8s-common/grafana/release-values.yaml
@@ -1,0 +1,2 @@
+# These values as applied last as downstream overrides
+# See https://github.com/grafana/helm-charts/blob/grafana-6.2.1/charts/grafana/values.yaml


### PR DESCRIPTION
Introduces a Grafana deployment template which includes default dashboards providing basic cluster insights from Prometheus metrics