### PR TITLE
feat(cert-manager): bump version to 1.5.3

### DIFF
--- a/.holo/sources/cert-manager.toml
+++ b/.holo/sources/cert-manager.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/jetstack/cert-manager"
-ref = "refs/heads/release-1.3"
+ref = "refs/heads/release-1.5"

--- a/k8s-common/cert-manager/default-values.yaml
+++ b/k8s-common/cert-manager/default-values.yaml
@@ -1,12 +1,12 @@
 # These values as applied first as template-provided defaults
 
 image:
-  tag: v1.3.2
+  tag: v1.5.3
 
 webhook:
   image:
-    tag: v1.3.2
+    tag: v1.5.3
 
 cainjector:
   image:
-    tag: v1.3.2
+    tag: v1.5.3


### PR DESCRIPTION
Not building currently because as of v1.4.x, `Chart.yaml` is [replaced by `Chart.template.yaml`](https://github.com/jetstack/cert-manager/tree/release-1.5/deploy/charts/cert-manager), we need a lens shell script or mapping to rename it and maybe replace its template placeholder(s)