### PR TITLE
Allow promtail to tolerate all nodes by default

### DIFF
--- a/k8s-common/promtail/default-values.yaml
+++ b/k8s-common/promtail/default-values.yaml
@@ -2,3 +2,9 @@
 
 config:
   lokiAddress: http://loki:3100/loki/api/v1/push
+
+tolerations:
+
+ # run on all nodes by default
+ - operator: Exists
+     effect: NoSchedule


### PR DESCRIPTION
Without this change, promtail will by default not run on any node pools which have taints applied to them.