### PR TITLE
Upgrade to Loki's V3 helm chart

### DIFF
--- a/.holo/branches/k8s-blueprint/loki/helm-chart.toml
+++ b/.holo/branches/k8s-blueprint/loki/helm-chart.toml
@@ -1,7 +1,8 @@
 [holomapping]
 holosource = "loki"
-root = "charts/loki"
+root = "production/helm/loki"
 files = [
-  "**",
-  "!templates/tests/**"
+  "*.yaml",
+  "src/**",
+  "templates/**"
 ]

--- a/.holo/sources/loki.toml
+++ b/.holo/sources/loki.toml
@@ -1,3 +1,3 @@
 [holosource]
-url = "https://github.com/grafana/helm-charts.git"
-ref = "refs/tags/loki-2.16.0"
+url = "https://github.com/grafana/loki"
+ref = "refs/tags/helm-loki-3.2.1"

--- a/k8s-common/.holo/lenses/loki.toml
+++ b/k8s-common/.holo/lenses/loki.toml
@@ -12,6 +12,7 @@ merge = "replace"
 [hololens.helm]
 namespace = "loki"
 release_name = "loki"
+namespace_fill = true
 
 chart_path = "helm-chart"
 value_files = [

--- a/k8s-common/loki/default-values.yaml
+++ b/k8s-common/loki/default-values.yaml
@@ -1,1 +1,6 @@
 # These values as applied first as template-provided defaults
+loki:
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: 'filesystem'

--- a/k8s-common/loki/release-values.yaml
+++ b/k8s-common/loki/release-values.yaml
@@ -1,2 +1,2 @@
 # These values as applied last as downstream overrides
-# See https://github.com/grafana/helm-charts/blob/main/charts/loki/values.yaml
+# See https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml


### PR DESCRIPTION
It's a significant refactor that combines all the previous variations into one ultra-configurable megachart

Before merging we'll want to tweak the default config to get it as close as possible to maintaining the previous setup for smooth upgrades