### PR TITLE
feat(cert-manager): bump to v1.20.2 (was v1.13.3)

### DIFF
--- a/.holo/branches/helm-charts/cert-manager.lenses/convert-bazel-templates.toml
+++ b/.holo/branches/helm-charts/cert-manager.lenses/convert-bazel-templates.toml
@@ -4,7 +4,7 @@ container = "ghcr.io/hologit/lenses/shell:latest"
 [hololens.shell]
 # Strip bazel templating in a bootleg fashion
 script = '''
-sed -i'' -E 's/^(appVersion|version):.*/\1: v1.10.1/g' Chart.template.yaml
+sed -i'' -E 's/^(appVersion|version):.*/\1: v1.20.2/g' Chart.template.yaml
 mv -v Chart.template.yaml Chart.yaml
 '''
 

--- a/.holo/sources/cert-manager.toml
+++ b/.holo/sources/cert-manager.toml
@@ -1,3 +1,3 @@
 [holosource]
-url = "https://github.com/jetstack/cert-manager"
-ref = "refs/tags/v1.13.3"
+url = "https://github.com/cert-manager/cert-manager"
+ref = "refs/tags/v1.20.2"

--- a/k8s-common/cert-manager/release-values.yaml
+++ b/k8s-common/cert-manager/release-values.yaml
@@ -1,2 +1,2 @@
 # These values as applied last as downstream overrides
-# See https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+# See https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml


### PR DESCRIPTION
## Summary

Bumps cert-manager from v1.13.3 → **v1.20.2** (latest stable, April 2026), unlocking Gateway API ListenerSet support for downstream consumers migrating off the deprecated ingress-nginx.

This is a **minor bump** for cluster-template (suggest v1.4.0): the chart's value-shape is backward-compatible — new options like `crds.*` and `enableGatewayAPI` are additive, opt-in via downstream `release-values.yaml`. Consumers who don't enable Gateway API support see no behavior change.

## Changes

| File | Change |
|---|---|
| `.holo/sources/cert-manager.toml` | `jetstack/cert-manager#v1.13.3` → `cert-manager/cert-manager#v1.20.2` (canonical repo + version bump) |
| `.holo/branches/helm-charts/cert-manager.lenses/convert-bazel-templates.toml` | bazel-template-stripper now substitutes `v1.20.2` instead of the stale hardcoded `v1.10.1` |
| `k8s-common/cert-manager/release-values.yaml` | comment URL update |

(The `Chart.template.yaml` → `Chart.yaml` workaround exists because cert-manager's source repo uses bazel templating that's normally resolved at release-packaging time; the `v1.10.1` literal was orphan from years ago and unrelated to the actual chart version since hologit always pulls from the source tree, not a packaged release.)

## Verification

Ran the projected chart through `helm template` with the existing default/provider/release value files:

```
--namespace cert-manager --release-name cert-manager --include-crds --kube-version 1.33
helm template exit: 0  (clean — no errors, no stderr)
stdout: 1,029,794 bytes
```

Resource counts (all expected):
- 6 CustomResourceDefinitions (Challenge, Order, CertificateRequest, Certificate, ClusterIssuer, Issuer)
- 3 Deployments (controller, cainjector, webhook)
- 3 Services + ServiceAccounts
- 1 Mutating + 1 Validating WebhookConfiguration
- 13 ClusterRoles, 10 ClusterRoleBindings, 4 Role/RoleBindings

## Why now

cfp-sandbox-cluster is starting a Gateway API migration (PRs #131-133, #143). cert-manager 1.20's `ListenerSet` support is the foundation needed before any Envoy Gateway work can land. Bumping here, then pulling through civic-cloud → cfp-sandbox-cluster, unblocks that whole chain.

## Migration notes for downstream consumers

After this lands and gets cut as a release:
- No required action — existing deployments continue working with vanilla `installCRDs: false` etc.
- To opt into Gateway API support, set in your `release-values.yaml`:
  ```yaml
  config:
    enableGatewayAPI: true
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)