### PR TITLE
fix(cert-manager): drop stale upstream helm-values.yaml mapping

### DIFF
--- a/.holo/branches/k8s-blueprint/cert-manager/_cert-manager.toml
+++ b/.holo/branches/k8s-blueprint/cert-manager/_cert-manager.toml
@@ -1,5 +1,0 @@
-[holomapping]
-root = "deploy/manifests"
-files = [
-    "helm-values.yaml"
-]

--- a/k8s-common/.holo/lenses/cert-manager.toml
+++ b/k8s-common/.holo/lenses/cert-manager.toml
@@ -7,7 +7,6 @@ release_name = "cert-manager"
 
 chart_path = "helm-chart"
 value_files = [
-    "helm-values.yaml",
     "default-values.yaml",
     "provider-values.yaml",
     "release-values.yaml"

--- a/k8s-common/cert-manager/default-values.yaml
+++ b/k8s-common/cert-manager/default-values.yaml
@@ -1,4 +1,13 @@
 # These values as applied first as template-provided defaults
 
+# Keep the deployment name as "cert-manager" instead of the helm-default
+# "cert-manager-cert-manager" so resource names stay stable across upgrades.
+fullnameOverride: cert-manager
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
 startupapicheck:
   enabled: false


### PR DESCRIPTION
## Summary

cert-manager's source repo ships an example values file at `deploy/manifests/helm-values.yaml` that's been pulled into every projection as the first values layer. After the v1.20 chart bump in #56, two of its keys are no longer accepted by the chart schema:

```
- at '/ingressShim': additional properties 'resources' not allowed
- at '/webhook': additional properties 'enabled' not allowed
```

Upstream cert-manager hasn't updated that file (still has the same broken keys on master — they probably don't test it against the chart's schema validator), so it's an unreliable input for us.

Without this fix, every downstream consumer has to add a workspace override like [cfp-sandbox-cluster's `cert-manager/helm-values.yaml`](https://github.com/CodeForPhilly/cfp-sandbox-cluster/pull/144/files) to neutralize it.

## Changes

| File | Change |
|---|---|
| `.holo/branches/k8s-blueprint/cert-manager/_cert-manager.toml` | deleted — the offending mapping |
| `k8s-common/.holo/lenses/cert-manager.toml` | drop `helm-values.yaml` from `value_files` |
| `k8s-common/cert-manager/default-values.yaml` | inline the still-valid bits: `fullnameOverride: cert-manager` (keeps deployment names stable across upgrades) and controller `resources.requests` |

## Verification

Re-projected `helm-charts/cert-manager` and ran helm template against the chart with `default-values.yaml` + `provider-values.yaml` + `release-values.yaml`:

- exit 0, no stderr, ~1.03MB output
- Deployment names: `cert-manager`, `cert-manager-webhook`, `cert-manager-cainjector` (not `cert-manager-cert-manager`)
- Controller resources: `requests: { cpu: 10m, memory: 32Mi }` applied
- Resource counts identical to before the change: 6 CRDs, 3 Deployments, 13 ClusterRoles, etc.

## Suggested release line

Patch bump — bug fix. `v1.4.0` → `v1.4.1`.

After this lands and gets released, downstream consumers can drop their workspace `cert-manager/helm-values.yaml` overrides on their next civic-cloud bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)