### PR TITLE
feat(gateway-api): add Envoy Gateway with cert-manager ListenerSet integration

### DIFF
--- a/.holo/branches/helm-charts/envoy-gateway.lenses/convert-templates.toml
+++ b/.holo/branches/helm-charts/envoy-gateway.lenses/convert-templates.toml
@@ -1,0 +1,22 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/shell:latest"
+
+[hololens.shell]
+# Envoy Gateway's chart ships values as a release-time template (values.tmpl.yaml
+# with shell-style ${...} placeholders) and Chart.yaml with v0.0.0-latest placeholders.
+# Substitute them here so the chart is helm-template-ready.
+script = '''
+sed -i'' \
+    -e 's|\${GatewayImage}|docker.io/envoyproxy/gateway:v1.7.3|g' \
+    -e 's|\${GatewayImagePullPolicy}|IfNotPresent|g' \
+    values.tmpl.yaml
+mv -v values.tmpl.yaml values.yaml
+
+sed -i'' -E 's/^(version|appVersion):.*/\1: v1.7.3/g' Chart.yaml
+'''
+
+[hololens.input]
+files = "**"
+
+[hololens.output]
+merge = "replace"

--- a/.holo/branches/helm-charts/envoy-gateway/_helm-chart.toml
+++ b/.holo/branches/helm-charts/envoy-gateway/_helm-chart.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "envoy-gateway"
+root = "charts/gateway-helm"
+files = "**"

--- a/.holo/branches/helm-charts/envoy-gateway/templates/_crds.toml
+++ b/.holo/branches/helm-charts/envoy-gateway/templates/_crds.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "envoy-gateway"
+root = "charts/gateway-helm/crds/generated"
+files = "*.yaml"

--- a/.holo/branches/k8s-blueprint/envoy-gateway/helm-chart.toml
+++ b/.holo/branches/k8s-blueprint/envoy-gateway/helm-chart.toml
@@ -1,0 +1,3 @@
+[holomapping]
+holosource = "jarvus-cluster-template=>helm-charts/envoy-gateway"
+files = "**"

--- a/.holo/branches/k8s-blueprint/gateway-api/_crds.toml
+++ b/.holo/branches/k8s-blueprint/gateway-api/_crds.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "gateway-api"
+root = "config/crd/standard"
+files = "gateway.networking.k8s.io_*.yaml"

--- a/.holo/sources/envoy-gateway.toml
+++ b/.holo/sources/envoy-gateway.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/envoyproxy/gateway"
+ref = "refs/tags/v1.7.3"

--- a/.holo/sources/gateway-api.toml
+++ b/.holo/sources/gateway-api.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/kubernetes-sigs/gateway-api"
+ref = "refs/tags/v1.5.1"

--- a/k8s-common/.holo/lenses/envoy-gateway.toml
+++ b/k8s-common/.holo/lenses/envoy-gateway.toml
@@ -1,0 +1,20 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.helm]
+namespace = "envoy-gateway-system"
+release_name = "envoy-gateway"
+
+chart_path = "helm-chart"
+value_files = [
+    "default-values.yaml",
+    "provider-values.yaml",
+    "release-values.yaml"
+]
+
+[hololens.input]
+root = "envoy-gateway"
+files = "**"
+
+[hololens.output]
+merge = "replace"

--- a/k8s-common/cert-manager/default-values.yaml
+++ b/k8s-common/cert-manager/default-values.yaml
@@ -18,3 +18,9 @@ startupapicheck:
 # the Gateway API CRDs aren't installed — cert-manager just skips the watch.
 config:
   enableGatewayAPI: true
+  # Enable ListenerSet support (alpha in cert-manager 1.20). Lets cert-manager
+  # issue Certificates for TLS terminations declared on Gateway API
+  # ListenerSet resources, which is the per-project cert pattern that
+  # downstream clusters use with Envoy Gateway.
+  featureGates:
+    ListenerSet: true

--- a/k8s-common/cert-manager/default-values.yaml
+++ b/k8s-common/cert-manager/default-values.yaml
@@ -11,3 +11,10 @@ resources:
 
 startupapicheck:
   enabled: false
+
+# Enable Gateway API integration. Cert-manager picks up `cert-manager.io/*`
+# annotations on Gateway and ListenerSet resources and issues Certificates for
+# their TLS terminations, the same way it does for Ingress. Safe even when
+# the Gateway API CRDs aren't installed — cert-manager just skips the watch.
+config:
+  enableGatewayAPI: true

--- a/k8s-common/envoy-gateway/default-values.yaml
+++ b/k8s-common/envoy-gateway/default-values.yaml
@@ -1,0 +1,1 @@
+# These values applied first as template-provided defaults

--- a/k8s-common/envoy-gateway/provider-values.yaml
+++ b/k8s-common/envoy-gateway/provider-values.yaml
@@ -1,0 +1,1 @@
+# These values applied second as provider-level defaults

--- a/k8s-common/envoy-gateway/release-values.yaml
+++ b/k8s-common/envoy-gateway/release-values.yaml
@@ -1,0 +1,2 @@
+# These values applied last as downstream overrides
+# See https://github.com/envoyproxy/gateway/blob/main/charts/gateway-helm/values.yaml


### PR DESCRIPTION
## Summary

Adds Envoy Gateway as the Gateway API implementation for downstream clusters migrating off ingress-nginx, with cert-manager wired up to issue Certificates for Gateway and ListenerSet TLS terminations.

Suggested release: **minor** (v1.4.1 → **v1.5.0**) — substantial new feature surface.

## What gets installed

| Component | Source | Notes |
|---|---|---|
| Gateway API CRDs (v1.5.1) | `kubernetes-sigs/gateway-api` | standard channel only — GatewayClass, Gateway, HTTPRoute, GRPCRoute, BackendTLSPolicy, ListenerSet, ReferenceGrant, TLSRoute. Plus 2 ValidatingAdmissionPolicy resources guarding against breaking CRD upgrades. |
| Envoy Gateway controller (v1.7.3) | `envoyproxy/gateway` | full helm chart: controller Deployment, RBAC, Service, ConfigMap, webhook, certgen Job — installs into `envoy-gateway-system`. |
| Envoy Gateway proprietary CRDs (v1.7.3) | same source | 8 CRDs: Backend, BackendTrafficPolicy, ClientTrafficPolicy, EnvoyExtensionPolicy, EnvoyPatchPolicy, EnvoyProxy, HTTPRouteFilter, SecurityPolicy. |
| cert-manager Gateway API integration | already-installed cert-manager 1.20.2 | `config.enableGatewayAPI: true` + `featureGates: { ListenerSet: true }` rendered into a ControllerConfiguration ConfigMap, wired into the controller pod via `--config=...` arg + volume mount. |

## Plumbing layout

Mirrors the cert-manager pattern:

```
.holo/sources/
  gateway-api.toml                                       # kubernetes-sigs/gateway-api @ v1.5.1
  envoy-gateway.toml                                     # envoyproxy/gateway @ v1.7.3

.holo/branches/k8s-blueprint/
  gateway-api/_crds.toml                                 # raw CRD mapping (standard channel)
  envoy-gateway/helm-chart.toml                          # self-projects helm-charts/envoy-gateway

.holo/branches/helm-charts/envoy-gateway/                # chart sub-projection
  _helm-chart.toml                                       # pulls charts/gateway-helm/**
  templates/_crds.toml                                   # pulls envoy-gateway's own CRDs into the chart's templates/ so helm renders them

.holo/branches/helm-charts/envoy-gateway.lenses/
  convert-templates.toml                                 # shell lens — substitutes ${GatewayImage} + v0.0.0-latest placeholders

k8s-common/.holo/lenses/envoy-gateway.toml               # helm3 lens
k8s-common/envoy-gateway/                                # values files (mostly empty for now)

k8s-common/cert-manager/default-values.yaml              # adds config.enableGatewayAPI + featureGates.ListenerSet
```

## Quirks

- **Envoy Gateway chart isn't ready-to-template from the source tree.** Like cert-manager, it ships `Chart.yaml` with `v0.0.0-latest` placeholders and a `values.tmpl.yaml` with `${GatewayImage}` / `${GatewayImagePullPolicy}` substitutions normally resolved at release time. The new shell lens fills those in.
- **Gateway API CRDs come from upstream sigs/gateway-api, not from envoy-gateway's bundled `charts/gateway-helm/crds/gatewayapi-crds.yaml`.** Keeps the CRD version independent of the Gateway implementation; lets us swap implementations later without ripping CRDs.
- **envoy-gateway's own CRDs** (Backend/BackendTrafficPolicy/etc.) ARE pulled raw from the chart source and placed into the chart's `templates/` so helm renders them — the chart leaves them in its `crds/generated/` directory which only renders with `--include-crds`, which our lens leaves off.

## Verification

Tested via the `HOLO_SOURCE_CLUSTER_TEMPLATE=file://...` override pattern from a downstream consumer (cfp-sandbox-cluster). Full chain projects cleanly:

- 8 Gateway API CRDs (standard) + 8 Envoy Gateway CRDs = **16 new CRDs**
- All controller resources render with correct labels/images
- `cert-manager/ConfigMap/cert-manager.yaml` carries `enableGatewayAPI: true` + `featureGates: { ListenerSet: true }`
- cert-manager Deployment gets `--config=/var/cert-manager/config/config.yaml` arg + the ConfigMap volume mount

Diff vs. pre-PR state (downstream): +38 files, ~77k insertions (mostly CRD content — HTTPRoute alone is 11.6k lines, SecurityPolicy 9.2k).

## Commits

- `d43d89b` feat(gateway-api): add Gateway API v1.5.1 CRDs
- `c1835a1` feat(envoy-gateway): add Envoy Gateway controller (v1.7.3)
- `706e53a` feat(envoy-gateway): substitute chart template placeholders at projection time
- `5be7bb2` feat(cert-manager): enable ListenerSet feature gate (alpha)

## Not included (intentional)

- **No sample Gateway / GatewayClass / ListenerSet resources.** Those are cluster-specific (hostnames, cert issuer refs, etc.) — downstream consumers define them in their own workspace.
- **No GatewayClass auto-selection.** Envoy Gateway's chart registers `eg` as the GatewayClass name; downstream Gateways reference it by `spec.gatewayClassName: eg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)