### PR TITLE
fix(cert-manager): use correct ListenerSet feature gate name (ListenerSets)

### DIFF
--- a/k8s-common/cert-manager/default-values.yaml
+++ b/k8s-common/cert-manager/default-values.yaml
@@ -22,5 +22,7 @@ config:
   # issue Certificates for TLS terminations declared on Gateway API
   # ListenerSet resources, which is the per-project cert pattern that
   # downstream clusters use with Envoy Gateway.
+  # Note: the gate is named `ListenerSets` (plural) in cert-manager's code;
+  # the 1.20 release notes refer to it as "the ListenerSet feature gate".
   featureGates:
-    ListenerSet: true
+    ListenerSets: true


### PR DESCRIPTION
## Summary

cert-manager 1.20.2's release notes refer to **\"the ListenerSet feature gate\"**, but the actual gate name in the controller's code is **\`ListenerSets\`** (plural). The current value in this file uses the singular form, which causes cert-manager's controller pod to crash-loop on startup:

\`\`\`
failed to set feature gates from initial flags-based config:
unrecognized feature gate: ListenerSet
\`\`\`

This was caught immediately when v1.5.0 deployed to cfp-sandbox-cluster — cert-manager went into CrashLoopBackOff.

## Verification

Confirmed correct name from cert-manager source at v1.20.2:

[\`internal/controller/feature/features.go\`](https://github.com/cert-manager/cert-manager/blob/v1.20.2/internal/controller/feature/features.go):
\`\`\`go
ListenerSets featuregate.Feature = \"ListenerSets\"
\`\`\`

## Suggested release

Patch — \`v1.5.0\` → **\`v1.5.1\`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)