### PR TITLE
chore(hairpin-proxy): remove from LKE blueprint

### DIFF
--- a/.holo/branches/k8s-blueprint-lke/hairpin-proxy.toml
+++ b/.holo/branches/k8s-blueprint-lke/hairpin-proxy.toml
@@ -1,2 +1,0 @@
-[holomapping]
-files = "deploy.yml"

--- a/.holo/sources/hairpin-proxy.toml
+++ b/.holo/sources/hairpin-proxy.toml
@@ -1,3 +1,0 @@
-[holosource]
-url = "https://github.com/JarvusInnovations/hairpin-proxy"
-ref = "refs/tags/v0.3.0"


### PR DESCRIPTION
## Summary

Removes hairpin-proxy from the k8s-blueprint-lke blueprint. It's no longer needed and is actively harmful in clusters migrating to Envoy Gateway.

## Why

**Originally needed because Linode LKE didn't hairpin LB traffic.** Pods inside the cluster couldn't reach the cluster's own LoadBalancer external IP — so requests to apps via their public hostnames would time out. hairpin-proxy worked around this by intercepting `*.<app-domain>` lookups in CoreDNS and routing them through haproxy → ingress-nginx ClusterIP.

**That limitation has been lifted.** Linode's network now allows in-cluster traffic to LoadBalancer external IPs. Verified by reaching `139.144.241.4` (Envoy LB) from inside a sandbox cluster pod and getting the expected response.

**Now actively harmful in Envoy Gateway clusters.** Since hairpin-proxy hardcodes ingress-nginx as the target, in-cluster requests still go through nginx — bypassing the new Envoy data plane. This:

- Breaks cert-manager's HTTP-01 self-check when ACME paths are served by Gateway API HTTPRoutes (cert-manager hits the nginx-routed app backend, not the ACME solver)
- Misroutes any in-cluster service mesh traffic to apps via their public hostnames

## Changes

- `.holo/sources/hairpin-proxy.toml` — deleted
- `.holo/branches/k8s-blueprint-lke/hairpin-proxy.toml` — deleted

## Downstream impact

When this lands and propagates through `civic-cluster-template` and downstream cluster repos, the projected manifests stop including:

- `hairpin-proxy` Namespace
- `hairpin-proxy-controller` Deployment + RBAC
- `hairpin-proxy-haproxy` Deployment + Service
- `coredns-custom` ConfigMap rewrites

Downstream operators will want to manually clean up the existing `coredns-custom` rewrites (the controller is responsible for adding them; once it's gone, removing them is one `kubectl patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)