### PR TITLE
feat(grafana): cert-manager email alerting via Postmark

### DIFF
--- a/docs/getting-started/service-setup/grafana-smtp.md
+++ b/docs/getting-started/service-setup/grafana-smtp.md
@@ -1,0 +1,73 @@
+# Grafana SMTP & certificate alerting
+
+The template ships certificate alert rules (in `k8s-common/grafana/default-values.yaml`)
+that email the cluster's operators when a certificate stops renewing. Grafana sends that
+mail through **Postmark**, and the credential, sender, and recipient list come from a
+`grafana-smtp` Secret in the `grafana` namespace.
+
+Until this Secret exists, Grafana still runs and the rules still evaluate — they just
+can't deliver. Creating it turns delivery on.
+
+## Why this is a Secret, and why Grafana rather than Alertmanager
+
+Postmark's server token is **both** the SMTP username and the password. Prometheus
+Alertmanager can read the SMTP password from a file but has no way to read the username
+from one, so on a public GitOps repo the token would end up committed in plaintext.
+Grafana reads both from a Secret as environment variables, exposing nothing — which is
+why alerting lives in Grafana here.
+
+The recipient list lives in the Secret too: it's usually personal addresses, and this
+keeps them out of a public repo.
+
+## Keys
+
+| Key | Value |
+| --- | --- |
+| `user` | Postmark **server token** |
+| `password` | the **same** Postmark server token |
+| `from-address` | a verified Postmark sender for this cluster (e.g. `alerts@example.org`) |
+| `recipients` | semicolon-separated list, e.g. `a@example.org;b@example.org` |
+
+The `from-address` must be a verified sender signature (or under a verified domain) in the
+Postmark server, or Postmark rejects the mail.
+
+## Create it
+
+Sealed into the cluster repo (recommended — survives a cluster rebuild):
+
+```bash
+TOKEN='<postmark-server-token>'
+kubectl create secret generic grafana-smtp \
+    --namespace grafana \
+    --dry-run=client -o json \
+    --from-literal=user="$TOKEN" \
+    --from-literal=password="$TOKEN" \
+    --from-literal=from-address='alerts@example.org' \
+    --from-literal=recipients='a@example.org;b@example.org' \
+  | kubeseal --format yaml \
+      --controller-namespace sealed-secrets --controller-name sealed-secrets \
+  > grafana/grafana-smtp.sealed.yaml
+```
+
+Commit the sealed file. For a quick non-GitOps setup, drop the `kubeseal` pipe and apply
+the plain Secret directly instead — but never commit an unsealed one.
+
+## Verify delivery
+
+Don't assume a rendered config delivers. After Grafana rolls out, fire a real test through
+its own notifier (a rendered-but-undeliverable pipeline is exactly the silent failure the
+alerts exist to prevent):
+
+```bash
+# Grafana's admin password lives in the grafana-initial-admin Secret.
+# Test the provisioned contact point with its real, env-expanded recipients:
+kubectl -n grafana exec deploy/grafana -- \
+  wget -qO- --post-data='{"receivers":[{"name":"cluster-alerts-email",
+    "grafana_managed_receiver_configs":[{"name":"cluster-alerts-email","type":"email",
+    "settings":{"addresses":"<your-address>","singleEmail":false}}]}],
+    "alert":{"annotations":{"summary":"alerting pipeline test"}}}' \
+  --header='Content-Type: application/json' \
+  "http://admin:$ADMIN_PW@localhost:3000/api/alertmanager/grafana/config/api/v1/receivers/test"
+```
+
+A `status: "ok"` and an email in the inbox means the pipeline works end to end.

--- a/k8s-common/grafana/default-values.yaml
+++ b/k8s-common/grafana/default-values.yaml
@@ -14,11 +14,15 @@ datasources:
     datasources:
 
       - name: Prometheus
+        # Pinned so provisioned alert rules can reference it stably across
+        # rebuilds — an auto-generated UID would differ on a fresh cluster.
+        uid: prometheus
         type: prometheus
         url: http://prometheus-server.prometheus.svc.cluster.local
         isDefault: true
 
       - name: Loki
+        uid: loki
         type: loki
         access: proxy
         url: http://loki.loki.svc.cluster.local:3100
@@ -72,6 +76,229 @@ dashboards:
 persistence:
 
   enabled: true
+
+# Email via Postmark, which every cluster on this template uses for SMTP. The
+# host is a safe template default; the credential, sender, and recipient list
+# are per-cluster and come from the `grafana-smtp` Secret (see
+# docs/getting-started/service-setup/grafana-smtp.md).
+#
+# Grafana rather than Prometheus Alertmanager, specifically because of Postmark:
+# its server token is BOTH the SMTP username and password, and Alertmanager can
+# read the password from a file but has no way to read the username from one —
+# so on a public repo the token would end up in git in plaintext. Grafana reads
+# both from a Secret as env, exposing nothing.
+grafana.ini:
+  smtp:
+    enabled: true
+    host: smtp.postmarkapp.com:587
+    from_name: Cluster Monitoring
+    # from_address comes from GF_SMTP_FROM_ADDRESS below (Grafana auto-maps
+    # GF_<SECTION>_<KEY> env vars onto grafana.ini, and env wins over this file).
+
+# All four are `optional: true` so a cluster that hasn't created grafana-smtp
+# still boots Grafana — alerting simply doesn't deliver until the Secret exists,
+# rather than blocking the pod on a missing reference.
+envValueFrom:
+  GF_SMTP_USER:
+    secretKeyRef: { name: grafana-smtp, key: user, optional: true }
+  GF_SMTP_PASSWORD:
+    secretKeyRef: { name: grafana-smtp, key: password, optional: true }
+  GF_SMTP_FROM_ADDRESS:
+    secretKeyRef: { name: grafana-smtp, key: from-address, optional: true }
+  ALERT_EMAIL_TO:
+    secretKeyRef: { name: grafana-smtp, key: recipients, optional: true }
+
+# Certificate alerting. cert-manager already exports these metrics and Prometheus
+# already scrapes them — without rules, nobody is looking. A cluster on this
+# template lost nine certificates at once in July 2026 and didn't notice for 56
+# days; the metrics were correct the whole time.
+#
+# noDataState/execErrState are OK by design: a deleted cert or a Prometheus blip
+# must not page. For a team that isn't watching dashboards, a false alarm is
+# worse than none — it trains everyone to ignore the next real one.
+alerting:
+  contactpoints.yaml:
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: cluster-alerts-email
+        receivers:
+          - uid: cluster-alerts-email
+            type: email
+            settings:
+              # Expanded from ALERT_EMAIL_TO (grafana-smtp Secret) at provisioning
+              # load — kept out of git because it's often personal addresses.
+              addresses: "${ALERT_EMAIL_TO}"
+              singleEmail: false
+
+  policies.yaml:
+    apiVersion: 1
+    policies:
+      - orgId: 1
+        receiver: cluster-alerts-email
+        group_by: ["alertname", "namespace", "name"]
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 12h
+
+  rules.yaml:
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: cert-manager
+        folder: Certificates
+        interval: 5m
+        rules:
+          # The load-bearing one. A Certificate reports Ready=True right up until
+          # it expires, so readiness catches nothing — what fails is renewal. A
+          # renewalTime more than a day in the past means renewal is stuck, and
+          # this fires ~29 days before expiry, while everything still looks fine.
+          - uid: cert-renewal-overdue
+            title: CertRenewalOverdue
+            condition: C
+            for: 1h
+            noDataState: OK
+            execErrState: OK
+            labels: { severity: warning }
+            annotations:
+              summary: '{{`Certificate {{ $labels.namespace }}/{{ $labels.name }} is overdue for renewal`}}'
+              description: >-
+                renewalTime is over a day in the past and renewal hasn't happened.
+                The cert is probably still valid, so nothing looks broken yet —
+                which is exactly how this failure mode hides. Check
+                `kubectl get challenges -A` for a stuck challenge.
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: prometheus
+                model:
+                  refId: A
+                  instant: true
+                  expr: time() - certmanager_certificate_renewal_timestamp_seconds
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: A
+                  conditions:
+                    - evaluator: { type: gt, params: [86400] }
+
+          # A healthy HTTP-01 challenge completes in seconds. One in flight for an
+          # hour is wrong; for days it's a half-orphaned Challenge (owner-ref'd to
+          # both its Order and the ClusterIssuer, so GC won't reap it once the
+          # Order is gone) holding its dnsName's scheduler slot and starving every
+          # future renewal for that hostname.
+          - uid: cert-challenge-stuck
+            title: CertChallengeStuck
+            condition: C
+            for: 1h
+            noDataState: OK
+            execErrState: OK
+            labels: { severity: warning }
+            annotations:
+              summary: '{{`ACME challenge stuck for {{ $labels.namespace }}/{{ $labels.name }}`}}'
+              description: >-
+                Challenge in flight for over an hour. Healthy ones resolve in
+                seconds. If its Order is gone it must be deleted by name, or it
+                starves every future renewal for this hostname.
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: prometheus
+                model:
+                  refId: A
+                  instant: true
+                  expr: certmanager_certificate_challenge_status
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: A
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+
+          - uid: cert-expiring-soon
+            title: CertExpiringSoon
+            condition: C
+            for: 1h
+            noDataState: OK
+            execErrState: OK
+            labels: { severity: warning }
+            annotations:
+              summary: '{{`Certificate {{ $labels.namespace }}/{{ $labels.name }} expires within 21 days`}}'
+              description: "Renewal starts at 30 days, so this has been failing for a week or more."
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: prometheus
+                model:
+                  refId: A
+                  instant: true
+                  expr: certmanager_certificate_expiration_timestamp_seconds - time()
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: A
+                  conditions:
+                    - evaluator: { type: lt, params: [1814400] }
+
+          - uid: cert-expiring-critical
+            title: CertExpiringCritical
+            condition: C
+            for: 10m
+            noDataState: OK
+            execErrState: OK
+            labels: { severity: critical }
+            annotations:
+              summary: '{{`Certificate {{ $labels.namespace }}/{{ $labels.name }} expires within 7 days`}}'
+              description: "Under a week to expiry. Users will see browser warnings when this lapses."
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: prometheus
+                model:
+                  refId: A
+                  instant: true
+                  expr: certmanager_certificate_expiration_timestamp_seconds - time()
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: A
+                  conditions:
+                    - evaluator: { type: lt, params: [604800] }
+
+          - uid: clusterissuer-not-ready
+            title: ClusterIssuerNotReady
+            condition: C
+            for: 15m
+            noDataState: OK
+            execErrState: OK
+            labels: { severity: critical }
+            annotations:
+              summary: '{{`ClusterIssuer {{ $labels.name }} is not Ready`}}'
+              description: "No certificate can be issued or renewed through this issuer."
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: prometheus
+                model:
+                  refId: A
+                  instant: true
+                  expr: certmanager_clusterissuer_ready_status{condition="True"}
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: A
+                  conditions:
+                    - evaluator: { type: lt, params: [1] }
 
 ingress:
 


### PR DESCRIPTION
Ships certificate alerting that actually reaches a human. cert-manager already exports the metrics and Prometheus already scrapes them — what was missing was anyone looking. A cluster on this template lost **nine certificates at once** in July 2026 and didn't notice for **56 days**; the metrics were correct the entire time.

> **Reworked** from the original Prometheus-rules version of this PR. Those rules were correct but **can't deliver** under the constraint below.

## Why Grafana, not Prometheus Alertmanager

Every cluster on this template uses **Postmark**, whose server token is *both* the SMTP username and password. Alertmanager can read the SMTP password from a file but has no `smtp_auth_username_file` — so on a public GitOps repo the token would sit in git in plaintext. Grafana reads both from a Secret as env, exposing nothing. That constraint is the whole reason delivery lives in Grafana.

## What ships in the template (generic)

- `grafana.ini [smtp]` → Postmark (same host for every cluster)
- `GF_SMTP_*` + `ALERT_EMAIL_TO` sourced from a `grafana-smtp` Secret, all `optional: true` so a cluster without it **still boots Grafana** (alerting just doesn't deliver until the Secret exists)
- Prometheus datasource UID pinned to `prometheus` so provisioned rules reference it stably across rebuilds
- 5 Grafana-managed alert rules, one email contact point, one policy

## What each cluster provides

The `grafana-smtp` Secret — Postmark token, a verified `from-address`, and the recipient list — documented in `getting-started/service-setup/grafana-smtp.md`. `from-address` and `recipients` come from the Secret too, keeping per-cluster and often-personal values out of the template.

## The rules

`CertRenewalOverdue` is load-bearing: a Certificate reports `Ready=True` until the moment it expires, so readiness catches nothing — what fails is *renewal*, and this fires when `renewalTime` falls a day behind, **~29 days before expiry**. `CertChallengeStuck` catches the half-orphan Challenge deadlock directly. Plus expiry backstops (21d/7d) and ClusterIssuer health. `noDataState`/`execErrState` are `OK` so a deleted cert or a Prometheus blip can't page.

## Validated

- All 5 rules load in a real `grafana:9.2.5` (ruler API).
- The `{{ $labels }}` in summaries are escaped `` {{`...`}} `` because the chart runs `tpl` over these values; verified the escape renders literally against the **same `grafana-6.44.10` chart** running in a downstream cluster.

## Rollout / validation plan

This lands in the template, then a downstream cluster (cfp-sandbox-cluster) pulls it and creates its `grafana-smtp` Secret — proving the change end to end before it reaches production clusters.