### PR TITLE
feat(grafana): source SMTP from_name from the grafana-smtp Secret

### DIFF
--- a/docs/getting-started/service-setup/grafana-smtp.md
+++ b/docs/getting-started/service-setup/grafana-smtp.md
@@ -26,10 +26,13 @@ keeps them out of a public repo.
 | `user` | Postmark **server token** |
 | `password` | the **same** Postmark server token |
 | `from-address` | a verified Postmark sender for this cluster (e.g. `alerts@example.org`) |
+| `from-name` | the sender name shown in alert emails — **name the cluster** so its origin is obvious at a glance, e.g. `CodeForPhilly — Live` |
 | `recipients` | semicolon-separated list, e.g. `a@example.org;b@example.org` |
 
 The `from-address` must be a verified sender signature (or under a verified domain) in the
-Postmark server, or Postmark rejects the mail.
+Postmark server, or Postmark rejects the mail. Set `from-name` distinctly per cluster —
+when several clusters share one Postmark server and email the same people, it's the only
+thing in the inbox that says which cluster fired.
 
 ## Create it
 
@@ -43,6 +46,7 @@ kubectl create secret generic grafana-smtp \
     --from-literal=user="$TOKEN" \
     --from-literal=password="$TOKEN" \
     --from-literal=from-address='alerts@example.org' \
+    --from-literal=from-name='CodeForPhilly — Live' \
     --from-literal=recipients='a@example.org;b@example.org' \
   | kubeseal --format yaml \
       --controller-namespace sealed-secrets --controller-name sealed-secrets \

--- a/k8s-common/grafana/default-values.yaml
+++ b/k8s-common/grafana/default-values.yaml
@@ -91,13 +91,16 @@ grafana.ini:
   smtp:
     enabled: true
     host: smtp.postmarkapp.com:587
+    # A generic fallback; each cluster overrides this with its own name via
+    # GF_SMTP_FROM_NAME (from the grafana-smtp Secret) so alert emails identify
+    # which cluster they came from. Grafana auto-maps GF_<SECTION>_<KEY> env vars
+    # onto grafana.ini and env wins over this file. from_address works the same
+    # way via GF_SMTP_FROM_ADDRESS.
     from_name: Cluster Monitoring
-    # from_address comes from GF_SMTP_FROM_ADDRESS below (Grafana auto-maps
-    # GF_<SECTION>_<KEY> env vars onto grafana.ini, and env wins over this file).
 
-# All four are `optional: true` so a cluster that hasn't created grafana-smtp
-# still boots Grafana — alerting simply doesn't deliver until the Secret exists,
-# rather than blocking the pod on a missing reference.
+# All `optional: true` so a cluster that hasn't created grafana-smtp still boots
+# Grafana — alerting simply doesn't deliver until the Secret exists, rather than
+# blocking the pod on a missing reference.
 envValueFrom:
   GF_SMTP_USER:
     secretKeyRef: { name: grafana-smtp, key: user, optional: true }
@@ -105,6 +108,9 @@ envValueFrom:
     secretKeyRef: { name: grafana-smtp, key: password, optional: true }
   GF_SMTP_FROM_ADDRESS:
     secretKeyRef: { name: grafana-smtp, key: from-address, optional: true }
+  # Names the sending cluster in alert emails, e.g. "CodeForPhilly Live".
+  GF_SMTP_FROM_NAME:
+    secretKeyRef: { name: grafana-smtp, key: from-name, optional: true }
   ALERT_EMAIL_TO:
     secretKeyRef: { name: grafana-smtp, key: recipients, optional: true }
 


### PR DESCRIPTION
Alert emails identify their cluster only if `from_name` does. The blueprint's default is a generic `Cluster Monitoring` on every cluster — so when several clusters share one Postmark server and email the same people (exactly CFP's setup), the inbox can't tell which cluster fired.

`from_name` is per-cluster identity, the same category as `from-address` and `recipients` that already live in the `grafana-smtp` Secret. This pairs it there:

- adds `GF_SMTP_FROM_NAME` to the grafana `envValueFrom`, sourced from the Secret's `from-name` key (`optional: true`, so a cluster without it falls back to the generic ini default — no boot failure)
- documents the `from-name` key with guidance to name the cluster distinctly

Follows v1.6.0's alerting; a cluster sets `from-name` when it creates the Secret, so it can't be forgotten.